### PR TITLE
Unset "parameter" in mergeTypoScript

### DIFF
--- a/Classes/Handler.php
+++ b/Classes/Handler.php
@@ -187,6 +187,9 @@ class Handler {
 			if (array_key_exists('parameter.', $typoLinkConfigurationArray)) {
 				unset($typoLinkConfigurationArray['parameter.']);
 			}
+			if (array_key_exists('parameter', $typoLinkConfigurationArray)) {
+				unset($typoLinkConfigurationArray['parameter']);
+			}
 			$linkConfigurationArray[$recordTableName . '.'] = array_merge($linkConfigurationArray[$recordTableName . '.'], $typoLinkConfigurationArray);
 		}
 


### PR DESCRIPTION
To prevent an endless loop in link generation when the link is not build via stdWrap the "parameter" needs to be unset in the mergeTypoScript method
