### PR TITLE
[BUGFIX] Pass array to AOE\Linkhandler\Handler::isRecordLinkable()

### DIFF
--- a/Classes/Handler.php
+++ b/Classes/Handler.php
@@ -133,6 +133,9 @@ class Handler {
 			$recordArray = $GLOBALS['TSFE']->sys_page->getRawRecord($recordTableName, $recordArray[$l18nPointer]);
 		}
 
+		if (!is_array($recordArray)) {
+			$recordArray = array();
+		}
 		$cache[$parameterHash] = $recordArray;
 		return $recordArray;
 	}


### PR DESCRIPTION
You get an exception when linking a non existent record:

PHP Catchable Fatal Error: Argument 3 passed to AOE\Linkhandler\Handler::isRecordLinkable() must be of the type array, null given, called in typo3conf/ext/linkhandler/Classes/Handler.php on line 61 and defined in typo3conf/ext/linkhandler/Classes/Handler.php line 88